### PR TITLE
Fixed error parsing .env when empty lines were present

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -21,15 +21,17 @@ while read -r line || [[ -n "$line" ]]; do
   if printf '%s\n' "$line" | grep -q -e '='; then
     varname=$(printf '%s\n' "$line" | sed -e 's/=.*//' | sed -e 's/REACT_APP_//') # Strip REACT_APP_ prefix
     varvalue=$(printf '%s\n' "$line" | sed -e 's/^[^=]*=//')
+
+    # Read value of current variable if exists as Environment variable
+    value=$(printf '%s\n' "${!varname}")
+    # Otherwise use value from .env file
+    [[ -z $value ]] && value=${varvalue}
+
+    # Append configuration property to JS file
+    echo "  $varname: \"$value\"," >>./env-config.js
   fi
 
-  # Read value of current variable if exists as Environment variable
-  value=$(printf '%s\n' "${!varname}")
-  # Otherwise use value from .env file
-  [[ -z $value ]] && value=${varvalue}
-
-  # Append configuration property to JS file
-  echo "  $varname: \"$value\"," >>./env-config.js
-done <.env
+done \
+  <.env
 
 echo "}" >>./env-config.js


### PR DESCRIPTION
During deployment tests, we noticed that a well formed `.env` file would be misinterpreted and cause errors if empty characters where placed before/after/between environment variables. This should fix it.