### PR TITLE
Store application data between pages

### DIFF
--- a/src/API.js
+++ b/src/API.js
@@ -364,7 +364,7 @@ class API {
             Input some Shape Expression (ShEx) and select its format, as well as
             a target validation engine and format to have your schema converted
           </p>
-          <p>
+          <span>
             Several target engines are supported, including:
             <ul>
               <li>ShEx and SHACL for schema to schema conversions</li>
@@ -389,7 +389,7 @@ class API {
                 for schema to forms conversions
               </li>
             </ul>
-          </p>
+          </span>
           <p>
             {API.engines.shex} to {API.engines.shacl} is still unsupported
           </p>
@@ -418,7 +418,7 @@ class API {
             Input a SHACL schema and select its format/engine, as well as a
             target validation engine and format to have your schema converted
           </p>
-          <p>
+          <span>
             Several target engines are supported, including:
             <ul>
               <li>
@@ -461,12 +461,12 @@ class API {
                 for WESO's ShEx/SHACL API
               </li>
             </ul>
-          </p>
+          </span>
         </>
       ),
 
       shapeMapInfo:
-        "Input a ShapeMap (by text, by pointing to a URL with the contents or by file) and select its format to validate its contents. Note that whole URIs must be used as there is no data/schema from which a prefix map can be retrieved",
+        "Input a ShapeMap (by text, by pointing to a URL with the contents or by file) and select its format to validate its contents. Whole URIs must be used since there is no data/schema from which a prefix map can be retrieved",
     },
 
     dataTabs: {
@@ -637,6 +637,8 @@ class API {
 
   // ID of the results container for any operation
   static resultsId = "results-container";
+  // Key for storing session temporary data in session storage
+  static sessionStorageDataKey = "applicationData";
 }
 
 export default API;

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,19 @@
-import React from "react";
+import React, { useState } from "react";
 import Container from "react-bootstrap/Container";
 import "./App.css";
+import {
+  initialApplicationContext
+} from "./context/ApplicationContext";
+import ApplicationProvider from "./context/ApplicationProvider";
 import Routes from "./Routes.js";
 
 function App() {
+  const [appContext, setAppContext] = useState(initialApplicationContext);
   return (
     <Container fluid={true}>
-      <Routes />
+      <ApplicationProvider>
+        <Routes />
+      </ApplicationProvider>
     </Container>
   );
 }

--- a/src/components/ByText.js
+++ b/src/components/ByText.js
@@ -9,7 +9,9 @@ import Code from "./Code";
 
 function ByText(props) {
   // Pre-process the text sent down to the text container
-  const textContent = props.textAreaValue?.trim();
+  const textContent = props.fromParams
+    ? props.textAreaValue?.trim()
+    : props.textAreaValue;
 
   function handleChange(value, y, change) {
     props.handleByTextChange && props.handleByTextChange(value, y, change);
@@ -24,20 +26,20 @@ function ByText(props) {
       Use a generic <Code> element with text by default */}
       {textFormat == API.formats.turtle.toLowerCase() ? (
         <TurtleForm
-          onChange={handleChange}
-          engine={props.textEngine}
-          fromParams={props.fromParams}
-          resetFromParams={props.resetFromParams}
           value={textContent}
-          options={{ placeholder: props.placeholder, ...props.options }}
-        />
-      ) : textFormat == API.formats.shexc.toLowerCase() ? (
-        <ShexForm
           onChange={handleChange}
           setCodeMirror={props.setCodeMirror}
           fromParams={props.fromParams}
           resetFromParams={props.resetFromParams}
+          options={{ placeholder: props.placeholder, ...props.options }}
+        />
+      ) : textFormat == API.formats.shexc.toLowerCase() ? (
+        <ShexForm
           value={textContent}
+          onChange={handleChange}
+          setCodeMirror={props.setCodeMirror}
+          fromParams={props.fromParams}
+          resetFromParams={props.resetFromParams}
           options={{ placeholder: props.placeholder, ...props.options }}
         />
       ) : (

--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -31,7 +31,7 @@ function Code(props) {
   useEffect(() => {
     if (editor) {
       if (props.fromParams) {
-        editor.setValue(props.value);
+        props.value && editor.setValue(props.value);
         props.resetFromParams && props.resetFromParams();
       }
     }

--- a/src/components/InputTabs.js
+++ b/src/components/InputTabs.js
@@ -24,7 +24,7 @@ function InputTabs(props) {
   return (
     <Form.Group>
       <Form.Label style={{ fontWeight: "bold" }}>{props.name}</Form.Label>
-      <Tabs activeKey={activeSource} id="dataTabs" onSelect={handleTabChange}>
+      <Tabs activeKey={activeSource} id="dataTabs" onSelect={handleTabChange} mountOnEnter={true}>
         <Tab eventKey={API.sources.byText} title="Text">
           <ByText
             name={props.byTextName}

--- a/src/components/InputTabsWithFormat.js
+++ b/src/components/InputTabsWithFormat.js
@@ -99,7 +99,11 @@ InputTabsWithFormat.defaultProps = {
   byUrlName: "",
   byUrlPlaceholder: "",
   byFileName: "",
+  fromParams: false,
   nameFormat: API.texts.dataTabs.formatHeader,
+
+  textAreaValue: "",
+  urlValue: "",
 };
 
 export default InputTabsWithFormat;

--- a/src/components/PageHeader.js
+++ b/src/components/PageHeader.js
@@ -32,7 +32,7 @@ const PageHeader = ({ title, details }) => {
 
 PageHeader.propTypes = {
   title: PropTypes.string.isRequired,
-  details: PropTypes.string,
+  details: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 };
 
 export default PageHeader;

--- a/src/components/SelectEngine.js
+++ b/src/components/SelectEngine.js
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useContext, useEffect } from "react";
 import API from "../API";
+import { ApplicationContext } from "../context/ApplicationContext";
 import SelectFormat from "./SelectFormat";
 
 export const allEngines = [
@@ -59,9 +60,20 @@ SelectEngine.defaultProps = {
 
 // Shorthand for SelectEngine preconfigured with Shacl engines
 export function SelectSHACLEngine(props) {
+  // Get schema and its setter from context
+  const { shaclSchema: ctxShacl, setShaclSchema: setCtxShacl } = useContext(
+    ApplicationContext
+  );
+
+  // Change context when the contained schema changes
+  useEffect(() => {
+    setCtxShacl(props.shacl);
+  }, [props.shacl]);
+
   return (
     <SelectEngine
       {...props}
+      selectedEngine={props.selectedEngine || ctxShacl.engine}
       urlEngines={API.routes.server.schemaShaclEngines}
     />
   );

--- a/src/context/ApplicationContext.js
+++ b/src/context/ApplicationContext.js
@@ -1,0 +1,23 @@
+import { createContext } from "react";
+import { InitialData } from "../data/Data";
+import { InitialQuery } from "../query/Query";
+import { InitialShacl } from "../shacl/Shacl";
+import { InitialShapeMap } from "../shapeMap/ShapeMap";
+import { InitialShex } from "../shex/Shex";
+import { InitialUML } from "../uml/UML";
+
+// Initial values in context
+export const initialApplicationContext = {
+  rdfData: InitialData, // Array of data (merge uses 2 units of data and more data compound could be added in the future)
+  sparqlQuery: InitialQuery,
+  sparqlEndpoint: "",
+  shexSchema: InitialShex,
+  shaclSchema: InitialShacl,
+  validationEndpoint: "", // Optional endpoint shown in ShaclValidate
+  shapeMap: InitialShapeMap,
+  umlData: InitialUML,
+};
+
+// Shared context for storing the data the user is operating on
+// and using it throughout the application (e.g.: for autifilling input forms when changing page)
+export const ApplicationContext = createContext(initialApplicationContext);

--- a/src/context/ApplicationContext.js
+++ b/src/context/ApplicationContext.js
@@ -1,5 +1,4 @@
 import { createContext } from "react";
-import { InitialData } from "../data/Data";
 import { InitialQuery } from "../query/Query";
 import { InitialShacl } from "../shacl/Shacl";
 import { InitialShapeMap } from "../shapeMap/ShapeMap";
@@ -8,7 +7,9 @@ import { InitialUML } from "../uml/UML";
 
 // Initial values in context
 export const initialApplicationContext = {
-  rdfData: InitialData, // Array of data (merge uses 2 units of data and more data compound could be added in the future)
+  // Array of data (merge uses 2 units of data and more data compound could be added in the future)
+  // See provider for the function to add new data
+  rdfData: [],
   sparqlQuery: InitialQuery,
   sparqlEndpoint: "",
   shexSchema: InitialShex,

--- a/src/context/ApplicationProvider.js
+++ b/src/context/ApplicationProvider.js
@@ -1,0 +1,142 @@
+import React, { useEffect, useReducer } from "react";
+import API from "../API";
+import { InitialData } from "../data/Data";
+import {
+  ApplicationContext,
+  initialApplicationContext
+} from "./ApplicationContext";
+
+// Resort to session storage to persist session data
+// Use Context API as middleware to parse and easily manipulate
+// the data in session storage
+// https://stackoverflow.com/a/62505656/9744696
+const ApplicationProvider = ({ children }) => {
+  // Reducer types
+  const reducerTypes = Object.freeze({
+    rdf: "rdf",
+    addRdf: "addRdf",
+    sparqlQuery: "sparql",
+    sparqlEnpoint: "sparqlEndpoint",
+    shex: "shex",
+    shacl: "shacl",
+    validationEndpoint: "validationEndpoint",
+    shapeMap: "shapeMap",
+    uml: "uml",
+  });
+
+  // Reducer function
+  function applicationDataReducer(state, { type, value }) {
+    // Last trap for nullish values
+    if (!value) return state;
+
+    // Trim text and URLs before storing
+    const trimBeforeStore = (item) => ({
+      ...item,
+      textArea: item.textArea.trim(),
+      url: item.url.trim(),
+    });
+
+    const finalValue = Array.isArray(value)
+      ? value.map(trimBeforeStore)
+      : typeof value === "object"
+      ? trimBeforeStore(value)
+      : typeof value === "string"
+      ? value.trim()
+      : value;
+
+    switch (type) {
+      case reducerTypes.rdf:
+        return { ...state, rdfData: finalValue };
+      case reducerTypes.addRdf:
+        return {
+          ...state,
+          rdfData: [...state.rdfData, finalValue],
+        };
+      case reducerTypes.sparqlQuery:
+        return { ...state, sparqlQuery: finalValue };
+      case reducerTypes.sparqlEnpoint:
+        return { ...state, sparqlEndpoint: finalValue };
+      case reducerTypes.shex:
+        return { ...state, shexSchema: finalValue };
+      case reducerTypes.shacl:
+        return { ...state, shaclSchema: finalValue };
+      case reducerTypes.validationEndpoint:
+        return { ...state, validationEndpoint: finalValue };
+      case reducerTypes.shapeMap:
+        return { ...state, shapeMap: finalValue };
+      case reducerTypes.uml:
+        return { ...state, umlData: finalValue };
+      default:
+        return state;
+    }
+  }
+
+  // Reducer to handle the application data
+  const [applicationData, dispatch] = useReducer(
+    applicationDataReducer,
+    getLocalStorage(API.sessionStorageDataKey, initialApplicationContext)
+  );
+
+  function setLocalStorage(key, value) {
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch (e) {
+      // catch possible errors
+    }
+  }
+
+  function getLocalStorage(key, initialValue) {
+    try {
+      const value = window.localStorage.getItem(key);
+      return value ? JSON.parse(value) : initialValue;
+    } catch (e) {
+      // if error, return initial value
+      return initialValue;
+    }
+  }
+
+  // Update session data when context data changed
+  useEffect(() => {
+    setLocalStorage(API.sessionStorageDataKey, applicationData);
+  }, [applicationData]);
+
+  return (
+    <ApplicationContext.Provider
+      value={{
+        ...applicationData,
+        // Granular control over the data to be updated
+        setRdfData: (rdfData) =>
+          dispatch({ type: reducerTypes.rdf, value: rdfData }),
+        addRdfData: (rdfData) => {
+          const newIndex = applicationData.rdfData.length; // new Data index based on current context data
+          const newData = rdfData // New data object, use InitialData if no data was provided
+            ? { index: newIndex, ...rdfData }
+            : {
+                index: newIndex,
+                ...InitialData,
+              };
+          dispatch({ type: reducerTypes.addRdf, value: newData }); // Update state and return new data
+          return newData;
+        },
+        setSparqlQuery: (sparqlQuery) =>
+          dispatch({ type: reducerTypes.sparqlQuery, value: sparqlQuery }),
+        setSparqlEndpoint: (sparqlEndpoint) =>
+          dispatch({ type: reducerTypes.sparqlEnpoint, value: sparqlEndpoint }),
+        setShexSchema: (shexSchema) =>
+          dispatch({ type: reducerTypes.shex, value: shexSchema }),
+        setShaclSchema: (shaclSchema) =>
+          dispatch({ type: reducerTypes.shacl, value: shaclSchema }),
+        setValidationEndpoint: (vEndpoint) =>
+          dispatch({ type: reducerTypes.validationEndpoint, value: vEndpoint }),
+        setShapeMap: (shapeMap) =>
+          dispatch({ type: reducerTypes.shapeMap, value: shapeMap }),
+        setUmlData: (umlData) =>
+          dispatch({ type: reducerTypes.uml, value: umlData }),
+      }}
+    >
+      {children}
+    </ApplicationContext.Provider>
+  );
+};
+
+export default ApplicationProvider;

--- a/src/context/ApplicationProvider.js
+++ b/src/context/ApplicationProvider.js
@@ -109,12 +109,11 @@ const ApplicationProvider = ({ children }) => {
           dispatch({ type: reducerTypes.rdf, value: rdfData }),
         addRdfData: (rdfData) => {
           const newIndex = applicationData.rdfData.length; // new Data index based on current context data
-          const newData = rdfData // New data object, use InitialData if no data was provided
-            ? { index: newIndex, ...rdfData }
-            : {
-                index: newIndex,
-                ...InitialData,
-              };
+          // New data object, use InitialData if no data was provided
+          const newData = {
+            index: newIndex,
+            ...(rdfData || InitialData),
+          };
           dispatch({ type: reducerTypes.addRdf, value: newData }); // Update state and return new data
           return newData;
         },

--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -77,7 +77,7 @@ export function mkDataTabs(
     setData({ ...data, activeSource: value });
   }
   function handleDataByTextChange(value, y, change) {
-    onTextChange(value, y, change);
+    // onTextChange(value, y, change);
     setData({ ...data, textArea: value });
   }
   function handleDataUrlChange(value) {

--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -92,11 +92,16 @@ export function mkDataTabs(
   function handleInferenceChange(value) {
     setData({ ...data, inference: value });
   }
+
+  function handleCodeMirrorChange(value) {
+    setData({ ...data, codeMirror: value });
+  }
   const resetParams = () => setData({ ...data, fromParams: false });
 
   return (
     <React.Fragment>
       <DataTabs
+        data={data}
         name={name}
         subname={subname}
         activeSource={data.activeSource}
@@ -108,11 +113,12 @@ export function mkDataTabs(
         handleFileUpload={handleDataFileUpload}
         selectedFormat={data.format}
         handleDataFormatChange={handleDataFormatChange}
-        setCodeMirror={(cm) => setData({ ...data, codeMirror: cm })}
+        setCodeMirror={handleCodeMirrorChange}
         fromParams={data.fromParams}
         resetFromParams={resetParams}
       />
       <SelectInferenceEngine
+        data={data}
         handleInferenceChange={handleInferenceChange}
         selectedInference={data.inference || InitialData.inference}
         fromParams={data.fromParams}

--- a/src/data/DataConvert.js
+++ b/src/data/DataConvert.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import qs from "query-string";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -11,6 +11,7 @@ import Row from "react-bootstrap/Row";
 import API from "../API";
 import PageHeader from "../components/PageHeader";
 import SelectFormat from "../components/SelectFormat";
+import { ApplicationContext } from "../context/ApplicationContext";
 import { mkPermalinkLong, params2Form } from "../Permalink";
 import ResultDataConvert from "../results/ResultDataConvert";
 import { mkError } from "../utils/ResponseError";
@@ -37,6 +38,9 @@ function DataConvert(props) {
 
   const [disabledLinks, setDisabledLinks] = useState(false);
 
+  // Recover user input data from context, if any. Use first item of the data array
+  const { rdfData: ctxData } = useContext(ApplicationContext);
+
   const url = API.routes.server.dataConvert;
 
   function handleTargetDataFormatChange(value) {
@@ -47,7 +51,10 @@ function DataConvert(props) {
     if (props.location?.search) {
       const queryParams = qs.parse(props.location.search);
       if (queryParams[API.queryParameters.data.data]) {
-        const finalData = updateStateData(queryParams, data) || data;
+        const finalData = {
+          index: 0,
+          ...(updateStateData(queryParams, data) || data),
+        };
         setData(finalData);
 
         if (queryParams[API.queryParameters.data.targetFormat]) {
@@ -67,6 +74,8 @@ function DataConvert(props) {
       } else {
         setError(API.texts.errorParsingUrl);
       }
+    } else if (ctxData && typeof ctxData === "object") {
+      setData(ctxData);
     }
   }, [props.location?.search]);
 
@@ -167,7 +176,7 @@ function DataConvert(props) {
   return (
     <Container fluid={true}>
       <Row>
-      <PageHeader
+        <PageHeader
           title={API.texts.pageHeaders.dataConversion}
           details={API.texts.pageExplanations.dataConversion}
         />

--- a/src/data/DataConvert.js
+++ b/src/data/DataConvert.js
@@ -17,29 +17,33 @@ import ResultDataConvert from "../results/ResultDataConvert";
 import { mkError } from "../utils/ResponseError";
 import {
   getDataText,
-  InitialData,
   mkDataTabs,
   paramsFromStateData,
   updateStateData
 } from "./Data";
 
 function DataConvert(props) {
-  const [result, setResult] = useState("");
-  const [params, setParams] = useState(null);
-  const [lastParams, setLastParams] = useState(null);
-  const [permalink, setPermalink] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [data, setData] = useState(InitialData);
+  const {
+    rdfData: [ctxData],
+    addRdfData,
+  } = useContext(ApplicationContext);
+
+  const [data, setData] = useState(ctxData || addRdfData());
   const [dataTargetFormat, setDataTargetFormat] = useState(
     API.formats.defaultData
   );
+  const [result, setResult] = useState("");
+
+  const [params, setParams] = useState(null);
+  const [lastParams, setLastParams] = useState(null);
+
+  const [permalink, setPermalink] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
   const [progressPercent, setProgressPercent] = useState(0);
 
   const [disabledLinks, setDisabledLinks] = useState(false);
-
-  // Recover user input data from context, if any. Use first item of the data array
-  const { rdfData: ctxData } = useContext(ApplicationContext);
 
   const url = API.routes.server.dataConvert;
 
@@ -74,8 +78,6 @@ function DataConvert(props) {
       } else {
         setError(API.texts.errorParsingUrl);
       }
-    } else if (ctxData && typeof ctxData === "object") {
-      setData(ctxData);
     }
   }, [props.location?.search]);
 

--- a/src/data/DataExtract.js
+++ b/src/data/DataExtract.js
@@ -17,16 +17,20 @@ import ResultDataExtract from "../results/ResultDataExtract";
 import NodeSelector from "../shex/NodeSelector";
 import { mkError } from "../utils/ResponseError";
 import {
-  getDataText,
-  InitialData,
-  mkDataTabs,
+  getDataText, mkDataTabs,
   paramsFromStateData,
   updateStateData
 } from "./Data";
 import { getNodesFromForm } from "./TurtleForm";
 
 function DataExtract(props) {
-  const [data, setData] = useState(InitialData);
+  // Recover user input data and query from context, if any. Use first item of the data array
+  const {
+    rdfData: [ctxData],
+    addRdfData,
+  } = useContext(ApplicationContext);
+
+  const [data, setData] = useState(ctxData || addRdfData());
   const [params, setParams] = useState(null);
   const [lastParams, setLastParams] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -40,11 +44,6 @@ function DataExtract(props) {
   const [progressPercent, setProgressPercent] = useState(0);
 
   const [disabledLinks, setDisabledLinks] = useState(false);
-
-  // Recover user input data and query from context, if any. Use first item of the data array
-  const {
-    rdfData: [ctxData],
-  } = useContext(ApplicationContext);
 
   const urlServerExtract = API.routes.server.dataExtract;
   const urlServerVisualize = API.routes.server.schemaConvert;
@@ -65,8 +64,6 @@ function DataExtract(props) {
         setParams(newParams);
         setLastParams(newParams);
       } else setError(API.texts.errorParsingUrl);
-    } else {
-      if (ctxData && typeof ctxData === "object") setData(ctxData);
     }
   }, [props.location?.search]);
 

--- a/src/data/DataExtract.js
+++ b/src/data/DataExtract.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import "bootstrap/dist/css/bootstrap.min.css";
 import qs from "query-string";
-import React, { Fragment, useEffect, useState } from "react";
+import React, { Fragment, useContext, useEffect, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -11,6 +11,7 @@ import ProgressBar from "react-bootstrap/ProgressBar";
 import Row from "react-bootstrap/Row";
 import API from "../API";
 import PageHeader from "../components/PageHeader";
+import { ApplicationContext } from "../context/ApplicationContext";
 import { mkPermalinkLong, params2Form } from "../Permalink";
 import ResultDataExtract from "../results/ResultDataExtract";
 import NodeSelector from "../shex/NodeSelector";
@@ -40,6 +41,11 @@ function DataExtract(props) {
 
   const [disabledLinks, setDisabledLinks] = useState(false);
 
+  // Recover user input data and query from context, if any. Use first item of the data array
+  const {
+    rdfData: [ctxData],
+  } = useContext(ApplicationContext);
+
   const urlServerExtract = API.routes.server.dataExtract;
   const urlServerVisualize = API.routes.server.schemaConvert;
 
@@ -47,7 +53,7 @@ function DataExtract(props) {
     if (props.location?.search) {
       const queryParams = qs.parse(props.location.search);
       if (queryParams[API.queryParameters.data.data]) {
-        const finalData = updateStateData(queryParams, data);
+        const finalData = { index: 0, ...updateStateData(queryParams, data) };
         setData(finalData);
 
         const finalNodeSelector =
@@ -59,6 +65,8 @@ function DataExtract(props) {
         setParams(newParams);
         setLastParams(newParams);
       } else setError(API.texts.errorParsingUrl);
+    } else {
+      if (ctxData && typeof ctxData === "object") setData(ctxData);
     }
   }, [props.location?.search]);
 

--- a/src/data/DataInfo.js
+++ b/src/data/DataInfo.js
@@ -16,15 +16,20 @@ import ResultDataInfo from "../results/ResultDataInfo";
 import { processDotData } from "../utils/dot/dotUtils";
 import { mkError } from "../utils/ResponseError";
 import {
-  getDataText,
-  InitialData,
-  mkDataTabs,
+  getDataText, mkDataTabs,
   paramsFromStateData,
   updateStateData
 } from "./Data";
 
 function DataInfo(props) {
-  const [data, setData] = useState(InitialData);
+  // Recover user input data from context, if any. Use first item of the data array
+  const {
+    rdfData: [ctxData],
+    addRdfData,
+  } = useContext(ApplicationContext);
+
+  // Set initial data from context, if possible
+  const [data, setData] = useState(ctxData || addRdfData());
 
   const [result, setResult] = useState(null);
 
@@ -40,9 +45,6 @@ function DataInfo(props) {
 
   const urlInfo = API.routes.server.dataInfo;
   const urlVisual = API.routes.server.dataConvert;
-
-  // Recover user input data from context, if any. Use first item of the data array
-  const { rdfData: ctxData } = useContext(ApplicationContext);
 
   // Try to autofill user data, first from the query string then from context
   useEffect(() => {
@@ -61,8 +63,6 @@ function DataInfo(props) {
       } else {
         setError(API.texts.errorParsingUrl);
       }
-    } else if (ctxData && typeof ctxData === "object") {
-      setData(ctxData); // Set the data in context so that UI changes
     }
   }, [props.location?.search]);
 

--- a/src/data/DataMerge.js
+++ b/src/data/DataMerge.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import qs from "query-string";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -11,6 +11,7 @@ import Row from "react-bootstrap/Row";
 import API from "../API";
 import PageHeader from "../components/PageHeader";
 import SelectFormat from "../components/SelectFormat";
+import { ApplicationContext } from "../context/ApplicationContext";
 import { mkPermalinkLong, params2Form } from "../Permalink";
 import ResultDataMerge from "../results/ResultDataMerge";
 import { mkError } from "../utils/ResponseError";
@@ -39,6 +40,9 @@ function DataMerge(props) {
 
   const [disabledLinks, setDisabledLinks] = useState(false);
 
+  // Recover user input data from context, if any. Use 2 items of the data array
+  const { rdfData: ctxData1, addRdfData } = useContext(ApplicationContext);
+
   const url = API.routes.server.dataConvert;
 
   function handleTargetDataFormatChange(value) {
@@ -58,8 +62,14 @@ function DataMerge(props) {
           const contents = JSON.parse(
             queryParams[API.queryParameters.data.compound]
           );
-          const newData1 = updateStateData(contents[0], data1) || data1;
-          const newData2 = updateStateData(contents[1], data2) || data2;
+          const newData1 = {
+            index: 0,
+            ...(updateStateData(contents[0], data1) || data1),
+          };
+          const newData2 = {
+            index: 1,
+            ...(updateStateData(contents[1], data2) || data2),
+          };
 
           setData1(newData1);
           setData2(newData2);
@@ -78,6 +88,13 @@ function DataMerge(props) {
       } else {
         setError(API.texts.errorParsingUrl);
       }
+    } else if (ctxData1 && typeof ctxData1 === "object") {
+      // Set the data in context so that UI changes
+      setData1(ctxData1);
+      // If there's no "data2" because it is the first time in the page, add a new data element
+      // to the data array in context
+      // setData2(ctxData2 || addRdfData());
+      setData2(InitialData);
     }
   }, [props.location?.search]);
 

--- a/src/data/DataMerge.js
+++ b/src/data/DataMerge.js
@@ -18,15 +18,19 @@ import { mkError } from "../utils/ResponseError";
 import { getFileContents } from "../utils/Utils";
 import {
   getDataText,
-  InitialData,
   mkDataTabs,
   paramsFromStateData,
   updateStateData
 } from "./Data";
 
 function DataMerge(props) {
-  const [data1, setData1] = useState(InitialData);
-  const [data2, setData2] = useState(InitialData);
+  // Recover user input data from context, if any. Use 2 items of the data array
+  const { rdfData: rdfDataSet, addRdfData } = useContext(ApplicationContext);
+  const [ctxData1, ctxData2] = rdfDataSet;
+
+  const [data1, setData1] = useState(ctxData1 || addRdfData());
+  const [data2, setData2] = useState(ctxData2 || addRdfData());
+
   const [params, setParams] = useState(null);
   const [lastParams, setLastParams] = useState(null);
   const [dataTargetFormat, setDataTargetFormat] = useState(
@@ -39,9 +43,6 @@ function DataMerge(props) {
   const [progressPercent, setProgressPercent] = useState(0);
 
   const [disabledLinks, setDisabledLinks] = useState(false);
-
-  // Recover user input data from context, if any. Use 2 items of the data array
-  const { rdfData: ctxData1, addRdfData } = useContext(ApplicationContext);
 
   const url = API.routes.server.dataConvert;
 
@@ -88,13 +89,6 @@ function DataMerge(props) {
       } else {
         setError(API.texts.errorParsingUrl);
       }
-    } else if (ctxData1 && typeof ctxData1 === "object") {
-      // Set the data in context so that UI changes
-      setData1(ctxData1);
-      // If there's no "data2" because it is the first time in the page, add a new data element
-      // to the data array in context
-      // setData2(ctxData2 || addRdfData());
-      setData2(InitialData);
     }
   }, [props.location?.search]);
 

--- a/src/data/DataQuery.js
+++ b/src/data/DataQuery.js
@@ -23,16 +23,21 @@ import {
 import ResultSparqlQuery from "../results/ResultSparqlQuery";
 import { mkError } from "../utils/ResponseError";
 import {
-  getDataText,
-  InitialData,
-  mkDataTabs,
+  getDataText, mkDataTabs,
   paramsFromStateData,
   updateStateData
 } from "./Data";
 
 function DataQuery(props) {
-  const [data, setData] = useState(InitialData);
-  const [query, setQuery] = useState(InitialQuery);
+  // Recover user input data and query from context, if any. Use first item of the data array
+  const {
+    rdfData: [ctxData],
+    sparqlQuery: ctxQuery,
+    addRdfData,
+  } = useContext(ApplicationContext);
+
+  const [data, setData] = useState(ctxData || addRdfData());
+  const [query, setQuery] = useState(ctxQuery || InitialQuery);
 
   const [params, setParams] = useState(null);
   const [lastParams, setLastParams] = useState(null);
@@ -45,12 +50,6 @@ function DataQuery(props) {
   const [progressPercent, setProgressPercent] = useState(0);
 
   const [disabledLinks, setDisabledLinks] = useState(false);
-
-  // Recover user input data and query from context, if any. Use first item of the data array
-  const {
-    rdfData: [ctxData],
-    sparqlQuery: ctxQuery,
-  } = useContext(ApplicationContext);
 
   const url = API.routes.server.dataQuery;
 
@@ -74,9 +73,6 @@ function DataQuery(props) {
 
       setParams(params);
       setLastParams(params);
-    } else {
-      if (ctxData && typeof ctxData === "object") setData(ctxData);
-      if (ctxQuery && typeof ctxQuery === "object") setQuery(ctxQuery);
     }
   }, [props.location?.search]);
 

--- a/src/data/DataQuery.js
+++ b/src/data/DataQuery.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import "bootstrap/dist/css/bootstrap.min.css";
 import qs from "query-string";
-import React, { Fragment, useEffect, useState } from "react";
+import React, { Fragment, useContext, useEffect, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -11,6 +11,7 @@ import ProgressBar from "react-bootstrap/ProgressBar";
 import Row from "react-bootstrap/Row";
 import API from "../API";
 import PageHeader from "../components/PageHeader";
+import { ApplicationContext } from "../context/ApplicationContext";
 import { mkPermalinkLong, params2Form } from "../Permalink";
 import {
   getQueryText,
@@ -45,33 +46,37 @@ function DataQuery(props) {
 
   const [disabledLinks, setDisabledLinks] = useState(false);
 
+  // Recover user input data and query from context, if any. Use first item of the data array
+  const {
+    rdfData: [ctxData],
+    sparqlQuery: ctxQuery,
+  } = useContext(ApplicationContext);
+
   const url = API.routes.server.dataQuery;
 
   useEffect(() => {
     if (props.location?.search) {
       const queryParams = qs.parse(props.location.search);
-      let paramsData,
-        paramsQuery = {};
 
-      if (queryParams[API.queryParameters.data.data]) {
-        const finalData = updateStateData(queryParams, data) || data;
-        paramsData = finalData;
-        setData(finalData);
-      }
+      const finalData = {
+        index: 0,
+        ...(updateStateData(queryParams, data) || data),
+      };
+      setData(finalData);
 
-      if (queryParams[API.queryParameters.query.query]) {
-        const finalQuery = updateStateQuery(queryParams, query) || query;
-        paramsQuery = finalQuery;
-        setQuery(finalQuery);
-      }
+      const finalQuery = updateStateQuery(queryParams, query) || query;
+      setQuery(finalQuery);
 
       const params = {
-        ...paramsFromStateData(paramsData),
-        ...paramsFromStateQuery(paramsQuery),
+        ...paramsFromStateData(finalData),
+        ...paramsFromStateQuery(finalQuery),
       };
 
       setParams(params);
       setLastParams(params);
+    } else {
+      if (ctxData && typeof ctxData === "object") setData(ctxData);
+      if (ctxQuery && typeof ctxQuery === "object") setQuery(ctxQuery);
     }
   }, [props.location?.search]);
 

--- a/src/data/DataTabs.js
+++ b/src/data/DataTabs.js
@@ -1,28 +1,46 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useContext, useEffect, useState } from "react";
 import API from "../API";
 import InputTabsWithFormat from "../components/InputTabsWithFormat";
+import { ApplicationContext } from "../context/ApplicationContext";
 
 function DataTabs(props) {
+  // Get data and its setter from context
+  const { rdfData: ctxDataSet, setRdfData: setCtxDataSet } = useContext(
+    ApplicationContext
+  );
+
+  const [dataIndex] = useState(props?.data?.index);
+
+  // Change context when the contained data changes
+  useEffect(() => {
+    // const newDataset = ctxDataSet.reduce(
+    //   (acc, curr, idx) =>
+    //     dataIndex === idx ? [...acc, props.data] : [...acc, curr],
+    //   []
+    // );
+    setCtxDataSet(props.data);
+  }, [props.data]);
+
   return (
     <div>
       <InputTabsWithFormat
         nameInputTab={props.name}
-        activeSource={props.activeSource}
+        activeSource={props.activeSource || ctxDataSet.activeSource} // Change according to data in context when needed
         handleTabChange={props.handleTabChange}
         byTextName={props.subname}
-        textAreaValue={props.textAreaValue}
+        textAreaValue={props.textAreaValue || ctxDataSet.textArea}
         byTextPlaceholder={API.texts.placeholders.rdf}
         handleByTextChange={props.handleByTextChange}
         handleUrlChange={props.handleDataUrlChange}
-        urlValue={props.urlValue}
+        urlValue={props.urlValue || ctxDataSet[dataIndex]?.url}
         byURLPlaceholder={API.texts.placeholders.url}
         handleFileUpload={props.handleFileUpload}
-        selectedFormat={props.selectedFormat}
+        selectedFormat={props.selectedFormat || ctxDataSet.format}
         handleFormatChange={props.handleDataFormatChange}
         urlFormats={API.routes.server.dataFormatsInput}
         setCodeMirror={props.setCodeMirror}
-        fromParams={props.fromParams}
+        fromParams={props.fromParams || ctxDataSet.fromParams}
         resetFromParams={props.resetFromParams}
       />
     </div>
@@ -30,6 +48,7 @@ function DataTabs(props) {
 }
 
 DataTabs.propTypes = {
+  data: PropTypes.object.isRequired,
   activeSource: PropTypes.string,
   handleTabChange: PropTypes.func.isRequired,
   textAreaValue: PropTypes.string,

--- a/src/data/DataTabs.js
+++ b/src/data/DataTabs.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect } from "react";
 import API from "../API";
 import InputTabsWithFormat from "../components/InputTabsWithFormat";
 import { ApplicationContext } from "../context/ApplicationContext";
@@ -10,37 +10,40 @@ function DataTabs(props) {
     ApplicationContext
   );
 
-  const [dataIndex] = useState(props?.data?.index);
+  const dataIndex = props?.data?.index;
 
   // Change context when the contained data changes
   useEffect(() => {
-    // const newDataset = ctxDataSet.reduce(
-    //   (acc, curr, idx) =>
-    //     dataIndex === idx ? [...acc, props.data] : [...acc, curr],
-    //   []
-    // );
-    setCtxDataSet(props.data);
+    if (props.data) {
+      // Reducer, insert the modified data in the corresponding index
+      const newDataset = ctxDataSet.reduce(
+        (acc, curr) =>
+          dataIndex === curr.index ? [...acc, props.data] : [...acc, curr],
+        []
+      );
+      setCtxDataSet(newDataset);
+    }
   }, [props.data]);
 
   return (
     <div>
       <InputTabsWithFormat
         nameInputTab={props.name}
-        activeSource={props.activeSource || ctxDataSet.activeSource} // Change according to data in context when needed
+        activeSource={props.activeSource || ctxDataSet[dataIndex]?.activeSource} // Change according to data in context when needed
         handleTabChange={props.handleTabChange}
         byTextName={props.subname}
-        textAreaValue={props.textAreaValue || ctxDataSet.textArea}
+        textAreaValue={props.textAreaValue || ctxDataSet[dataIndex]?.textArea}
         byTextPlaceholder={API.texts.placeholders.rdf}
         handleByTextChange={props.handleByTextChange}
         handleUrlChange={props.handleDataUrlChange}
         urlValue={props.urlValue || ctxDataSet[dataIndex]?.url}
         byURLPlaceholder={API.texts.placeholders.url}
         handleFileUpload={props.handleFileUpload}
-        selectedFormat={props.selectedFormat || ctxDataSet.format}
+        selectedFormat={props.selectedFormat || ctxDataSet[dataIndex]?.format}
         handleFormatChange={props.handleDataFormatChange}
         urlFormats={API.routes.server.dataFormatsInput}
         setCodeMirror={props.setCodeMirror}
-        fromParams={props.fromParams || ctxDataSet.fromParams}
+        fromParams={props.fromParams || ctxDataSet[dataIndex]?.fromParams}
         resetFromParams={props.resetFromParams}
       />
     </div>

--- a/src/data/SelectInferenceEngine.js
+++ b/src/data/SelectInferenceEngine.js
@@ -14,6 +14,9 @@ function SelectInferenceEngine(props) {
     ? inferenceTargets.shacl
     : inferenceTargets.rdf;
 
+  // In case we are manipulating data, the index in the data array that we are manipulating
+  const dataIndex = props?.data?.index;
+
   // Get potentially necessary data from context
   const {
     rdfData: ctxDataSet,
@@ -25,23 +28,21 @@ function SelectInferenceEngine(props) {
   useEffect(() => {
     switch (inferenceTarget) {
       case inferenceTargets.rdf:
-        setCtxDataSet(props.data);
-      // setCtxDataSet(
-      //   ctxDataSet.reduce(
-      //     (acc, curr, idx) =>
-      //       props.data.index === idx ? [...acc, props.data] : [...acc, curr],
-      //     []
-      //   )
-      // );
+        // setCtxDataSet(props.data);
+        // setCtxDataSet([props.data]);
+        setCtxDataSet(
+          ctxDataSet.reduce(
+            (acc, curr) =>
+              dataIndex === curr.index ? [...acc, props.data] : [...acc, curr],
+            []
+          )
+        );
       case inferenceTargets.shacl:
         setCtxShacl(props.shacl);
       default:
         return;
     }
   }, [props.data, props.shacl]);
-
-  // In case we are manipulating data, the index in the data array that we are manipulating
-  const dataIndex = props?.data?.index || 0;
 
   return (
     <SelectFormat
@@ -50,7 +51,7 @@ function SelectInferenceEngine(props) {
         props.selectedInference ||
         (inferenceTarget === inferenceTargets.shacl
           ? ctxShacl.inference
-          : ctxDataSet.inference)
+          : ctxDataSet[dataIndex]?.inference)
       }
       urlFormats={API.routes.server.inferenceEngines}
       name={props.name}

--- a/src/data/SelectInferenceEngine.js
+++ b/src/data/SelectInferenceEngine.js
@@ -1,13 +1,57 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useContext, useEffect } from "react";
 import API from "../API";
 import SelectFormat from "../components/SelectFormat";
+import { ApplicationContext } from "../context/ApplicationContext";
 
 function SelectInferenceEngine(props) {
+  // We may be selecting the inference for RDF or for SHACL
+  const inferenceTargets = Object.freeze({
+    rdf: "rdf",
+    shacl: "shacl",
+  });
+  const inferenceTarget = props.shacl
+    ? inferenceTargets.shacl
+    : inferenceTargets.rdf;
+
+  // Get potentially necessary data from context
+  const {
+    rdfData: ctxDataSet,
+    setRdfData: setCtxDataSet,
+    shaclSchema: ctxShacl,
+    setShaclSchema: setCtxShacl,
+  } = useContext(ApplicationContext);
+
+  useEffect(() => {
+    switch (inferenceTarget) {
+      case inferenceTargets.rdf:
+        setCtxDataSet(props.data);
+      // setCtxDataSet(
+      //   ctxDataSet.reduce(
+      //     (acc, curr, idx) =>
+      //       props.data.index === idx ? [...acc, props.data] : [...acc, curr],
+      //     []
+      //   )
+      // );
+      case inferenceTargets.shacl:
+        setCtxShacl(props.shacl);
+      default:
+        return;
+    }
+  }, [props.data, props.shacl]);
+
+  // In case we are manipulating data, the index in the data array that we are manipulating
+  const dataIndex = props?.data?.index || 0;
+
   return (
     <SelectFormat
       handleFormatChange={props.handleInferenceChange}
-      selectedFormat={props.selectedInference}
+      selectedFormat={
+        props.selectedInference ||
+        (inferenceTarget === inferenceTargets.shacl
+          ? ctxShacl.inference
+          : ctxDataSet.inference)
+      }
       urlFormats={API.routes.server.inferenceEngines}
       name={props.name}
     />
@@ -15,6 +59,9 @@ function SelectInferenceEngine(props) {
 }
 
 SelectInferenceEngine.propTypes = {
+  data: PropTypes.object,
+  shacl: PropTypes.object,
+
   handleInferenceChange: PropTypes.func.isRequired,
   selectedInference: PropTypes.string.isRequired,
   resetFromParams: PropTypes.func,

--- a/src/data/TurtleForm.js
+++ b/src/data/TurtleForm.js
@@ -9,26 +9,30 @@ function TurtleForm(props) {
   const textAreaRef = useRef(null);
 
   useEffect(() => {
-    if (!yate) {
-      const options = {
-        readOnly: true,
-        autoCloseTags: true,
-        start: { line: 0 },
-        lineNumbers: true,
-        lineWrapping: true,
-        ...props.options,
-      };
+    const options = {
+      readOnly: true,
+      autoCloseTags: true,
+      start: { line: 0 },
+      lineNumbers: true,
+      lineWrapping: true,
+      ...props.options,
+    };
 
+    if (!yate) {
       const y = YATE.fromTextArea(textAreaRef.current, options);
       y.on("change", (cm, change) => {
-        props.onChange(cm.getValue(), cm, change);
+        props.onChange && props.onChange(cm.getValue(), cm, change);
       });
-      y.setValue(props.value);
+      // If a non-empty value is passed from parent, use it
+
+      props.value && y.setValue(props.value);
       y.refresh();
       setYate(y);
-    } else if (props.fromParams) {
-      yate.setValue(props.value);
-      props.resetFromParams && props.resetFromParams();
+    } else {
+      if (props.fromParams) {
+        yate.setValue(props.value);
+        props.resetFromParams && props.resetFromParams();
+      }
     }
   }, [
     yate,

--- a/src/endpoint/EndpointInfo.js
+++ b/src/endpoint/EndpointInfo.js
@@ -16,7 +16,9 @@ import { mkError } from "../utils/ResponseError";
 import EndpointInput from "./EndpointInput";
 
 function EndpointInfo(props) {
-  const [endpoint, setEndpoint] = useState("");
+  const { sparqlEndpoint: ctxEndpoint } = useContext(ApplicationContext);
+
+  const [endpoint, setEndpoint] = useState(ctxEndpoint || "");
   const [params, setParams] = useState(null);
   const [lastParams, setLastParams] = useState(null);
   const [result, setResult] = useState(null);
@@ -24,8 +26,6 @@ function EndpointInfo(props) {
   const [loading, setLoading] = useState(false);
   const [permalink, setPermalink] = useState(null);
   const [progressPercent, setProgressPercent] = useState(0);
-
-  const { sparqlEndpoint: ctxEndpoint } = useContext(ApplicationContext);
 
   const url = API.routes.server.endpointInfo;
 
@@ -43,9 +43,6 @@ function EndpointInfo(props) {
       } else {
         setError(API.texts.errorParsingUrl);
       }
-    } else {
-      if (ctxEndpoint && typeof ctxEndpoint === "string")
-        setEndpoint(ctxEndpoint);
     }
   }, [props.location?.search]);
 

--- a/src/endpoint/EndpointInput.js
+++ b/src/endpoint/EndpointInput.js
@@ -1,28 +1,34 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useContext, useEffect } from "react";
 import Dropdown from "react-bootstrap/Dropdown";
 import DropdownButton from "react-bootstrap/DropdownButton";
 import Form from "react-bootstrap/Form";
 import API from "../API";
+import { ApplicationContext } from "../context/ApplicationContext";
 
-function EndpointInput({ value, handleOnChange, handleOnSelect }) {
-  const endpoints = [
+function EndpointInput({ endpoint, handleOnChange, handleOnSelect }) {
+  const {
+    sparqlEndpoint: ctxEndpoint,
+    setSparqlEndpoint: setCtxEndpoint,
+  } = useContext(ApplicationContext);
+
+  // Endpoints shown on dropdown list
+  const exampleEndpoints = [
     { name: "wikidata", url: API.routes.utils.wikidataUrl },
     { name: "dbpedia", url: API.routes.utils.dbpediaUrl },
   ];
 
-  const dropDownItems = endpoints.map((endpoint, index) => (
-    <Dropdown.Item key={index} eventKey={endpoint.url}>
-      {endpoint.name}
-    </Dropdown.Item>
-  ));
+  useEffect(() => {
+    setCtxEndpoint(endpoint);
+  }, [endpoint]);
 
   function onChange(e) {
-    handleOnChange(e.target.value);
+    e.preventDefault();
+    handleOnChange && handleOnChange(e.target.value);
   }
 
   function onSelect(e) {
-    handleOnSelect && handleOnSelect();
+    handleOnSelect && handleOnSelect(e);
     handleOnChange(e);
   }
 
@@ -30,10 +36,9 @@ function EndpointInput({ value, handleOnChange, handleOnSelect }) {
     <Form.Group id="common-endpoints">
       <Form.Label>Endpoint</Form.Label>
       <Form.Control
-        as="input"
         type="url"
         placeholder={API.texts.placeholders.url}
-        value={value}
+        value={endpoint || ctxEndpoint}
         onChange={onChange}
       />
       <Dropdown onSelect={onSelect}>
@@ -42,7 +47,11 @@ function EndpointInput({ value, handleOnChange, handleOnSelect }) {
           title={API.texts.endpoints.commonEndpoints}
           id="select-endpoint"
         >
-          {dropDownItems}
+          {exampleEndpoints.map((endpoint, index) => (
+            <Dropdown.Item key={index} eventKey={endpoint.url}>
+              {endpoint.name}
+            </Dropdown.Item>
+          ))}
         </DropdownButton>
       </Dropdown>
     </Form.Group>
@@ -50,7 +59,7 @@ function EndpointInput({ value, handleOnChange, handleOnSelect }) {
 }
 
 EndpointInput.propTypes = {
-  value: PropTypes.string.isRequired,
+  endpoint: PropTypes.string.isRequired,
   handleOnChange: PropTypes.func.isRequired,
   handleOnSelect: PropTypes.func,
 };

--- a/src/endpoint/EndpointQuery.js
+++ b/src/endpoint/EndpointQuery.js
@@ -24,21 +24,25 @@ import { mkError } from "../utils/ResponseError";
 import EndpointInput from "./EndpointInput";
 
 function EndpointQuery(props) {
-  const [endpoint, setEndpoint] = useState("");
-  const [params, setParams] = useState(null);
-  const [lastParams, setLastParams] = useState(null);
-  const [result, setResult] = useState("");
-  const [error, setError] = useState("");
-  const [query, setQuery] = useState(InitialQuery);
-  const [permalink, setPermalink] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [progressPercent, setProgressPercent] = useState(0);
-  const [controlPressed, setControlPressed] = useState(false);
-
   // Recover user endpoint and query from context, if any
   const { sparqlEndpoint: ctxEndpoint, sparqlQuery: ctxQuery } = useContext(
     ApplicationContext
   );
+
+  const [endpoint, setEndpoint] = useState(ctxEndpoint || "");
+  const [query, setQuery] = useState(ctxQuery || InitialQuery);
+
+  const [params, setParams] = useState(null);
+  const [lastParams, setLastParams] = useState(null);
+
+  const [result, setResult] = useState("");
+  const [error, setError] = useState("");
+
+  const [permalink, setPermalink] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const [progressPercent, setProgressPercent] = useState(0);
+  const [controlPressed, setControlPressed] = useState(false);
 
   const url = API.routes.server.wikibaseQuery;
 
@@ -58,10 +62,6 @@ function EndpointQuery(props) {
 
       setParams(newParams);
       setLastParams(newParams);
-    } else {
-      if (ctxEndpoint && typeof ctxEndpoint === "string")
-        setEndpoint(ctxEndpoint);
-      if (ctxQuery && typeof ctxQuery === "object") setQuery(ctxQuery);
     }
   }, [props.location?.search]);
 

--- a/src/endpoint/EndpointQuery.js
+++ b/src/endpoint/EndpointQuery.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import qs from "query-string";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Spinner } from "react-bootstrap";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
@@ -9,6 +9,7 @@ import Form from "react-bootstrap/Form";
 import Row from "react-bootstrap/Row";
 import API from "../API";
 import PageHeader from "../components/PageHeader";
+import { ApplicationContext } from "../context/ApplicationContext";
 import { mkPermalinkLong, params2Form } from "../Permalink";
 import {
   getQueryRaw,
@@ -34,37 +35,33 @@ function EndpointQuery(props) {
   const [progressPercent, setProgressPercent] = useState(0);
   const [controlPressed, setControlPressed] = useState(false);
 
+  // Recover user endpoint and query from context, if any
+  const { sparqlEndpoint: ctxEndpoint, sparqlQuery: ctxQuery } = useContext(
+    ApplicationContext
+  );
+
   const url = API.routes.server.wikibaseQuery;
 
   useEffect(() => {
     if (props.location?.search) {
       const queryParams = qs.parse(props.location.search);
-      let paramsQuery,
-        paramsEndpoint = {};
 
-      // Query State
-      if (queryParams[API.queryParameters.query.query]) {
-        paramsQuery = updateStateQuery(queryParams, query) || query;
-        setQuery(paramsQuery);
-      }
+      const finalQuery = updateStateQuery(queryParams, query) || query;
+      setQuery(finalQuery);
 
-      // Endpoint State
-      if (queryParams[API.queryParameters.endpoint.endpoint]) {
-        paramsEndpoint = {
-          [API.queryParameters.endpoint.endpoint]:
-            queryParams[API.queryParameters.endpoint.endpoint],
-        };
-        setEndpoint(queryParams[API.queryParameters.endpoint.endpoint]);
-      }
+      const finalEndpoint =
+        queryParams[API.queryParameters.endpoint.endpoint] || endpoint;
+      setEndpoint(finalEndpoint);
 
       // Params to be used in first query
-      let params = {
-        ...paramsFromStateQuery(paramsQuery),
-        ...paramsEndpoint,
-      };
+      const newParams = mkParams(finalEndpoint, finalQuery);
 
-      setParams(params);
-      setLastParams(params);
+      setParams(newParams);
+      setLastParams(newParams);
+    } else {
+      if (ctxEndpoint && typeof ctxEndpoint === "string")
+        setEndpoint(ctxEndpoint);
+      if (ctxQuery && typeof ctxQuery === "object") setQuery(ctxQuery);
     }
   }, [props.location?.search]);
 
@@ -108,10 +105,14 @@ function EndpointQuery(props) {
 
   async function handleSubmit(event) {
     event.preventDefault();
-    setParams({
-      ...paramsFromStateQuery(query),
-      [API.queryParameters.endpoint.endpoint]: endpoint,
-    });
+    setParams(mkParams());
+  }
+
+  function mkParams(pEndpoint = endpoint, pQuery = query) {
+    return {
+      [API.queryParameters.endpoint.endpoint]: pEndpoint,
+      ...paramsFromStateQuery(pQuery),
+    };
   }
 
   async function postQuery() {
@@ -186,7 +187,7 @@ function EndpointQuery(props) {
         onKeyUp={onKeyUp}
       >
         <EndpointInput
-          value={endpoint}
+          endpoint={endpoint}
           handleOnChange={handleOnChange}
           handleOnSelect={handleOnSelect}
         />

--- a/src/query/Query.js
+++ b/src/query/Query.js
@@ -71,6 +71,7 @@ export function mkQueryTabs(query, setQuery, name, subname) {
 
   return (
     <QueryTabs
+      query={query}
       name={name}
       subname={subname}
       activeSource={query.activeSource}

--- a/src/query/QueryTabs.js
+++ b/src/query/QueryTabs.js
@@ -1,10 +1,19 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useContext, useEffect } from "react";
 import API from "../API";
 import InputTabs from "../components/InputTabs";
+import { ApplicationContext } from "../context/ApplicationContext";
 import QueryForm from "./QueryForm";
 
 function QueryTabs(props) {
+  // Get query and its setter from context
+  const { sparqlQuery, setSparqlQuery } = useContext(ApplicationContext);
+
+  // Change context when the contained query changes
+  useEffect(() => {
+    setSparqlQuery(props.query);
+  }, [props.query]);
+
   const queryForm = (
     <QueryForm
       onChange={props.handleByTextChange}
@@ -20,18 +29,18 @@ function QueryTabs(props) {
     <div>
       <InputTabs
         name={props.name}
-        activeSource={props.activeSource}
+        activeSource={props.activeSource || sparqlQuery.activeSource}
         handleTabChange={props.handleTabChange}
         byTextName={props.subname}
-        textAreaValue={props.textAreaValue}
+        textAreaValue={props.textAreaValue || sparqlQuery.textArea}
         handleByTextChange={props.handleByTextChange}
         byTextPlaceholder={API.texts.placeholders.sparqlQuery}
         inputForm={queryForm}
-        urlValue={props.urlValue}
+        urlValue={props.urlValue || sparqlQuery.url}
         handleUrlChange={props.handleUrlChange}
         byUrlPlaceholder={API.texts.placeholders.url}
         handleFileUpload={props.handleFileUpload}
-        fromParams={props.fromParams}
+        fromParams={props.fromParams || sparqlQuery.fromParams}
         resetFromParams={props.resetFromParams}
       />
     </div>

--- a/src/results/ResultDataConvert.js
+++ b/src/results/ResultDataConvert.js
@@ -43,7 +43,7 @@ function ResultDataConvert({
               <ByText
                 textAreaValue={dataRaw}
                 textFormat={format2mode(outputFormatName)}
-                fromParams={fromParams}
+                fromParams={true}
                 readOnly={true}
                 options={{ ...yasheResultButtonsOptions }}
               />

--- a/src/results/ResultSchemaConvert.js
+++ b/src/results/ResultSchemaConvert.js
@@ -40,7 +40,7 @@ function ResultSchemaConvert({
               <ByText
                 textAreaValue={outputSchema}
                 textFormat={outputFormatName}
-                fromParams={false}
+                fromParams={true}
                 options={{ ...yasheResultButtonsOptions }}
               />
             </Tab>

--- a/src/results/ResultShapeForm.js
+++ b/src/results/ResultShapeForm.js
@@ -71,7 +71,7 @@ function ResultShapeForm({ result: shapeFormResult, permalink, disabled }) {
                 indentation: "  ",
               })} // Pretty print generated HTML
               textFormat={API.formats.xml}
-              fromParams={false}
+              fromParams={true}
               readonly={true}
               options={{ ...yasheResultButtonsOptions }}
             />

--- a/src/results/ResultXmi2Shex.js
+++ b/src/results/ResultXmi2Shex.js
@@ -67,7 +67,7 @@ function ResultXMI2ShEx({
               <ByText
                 textAreaValue={resultRaw}
                 textFormat={API.formats.shexc} // Force ShExC for the text results
-                fromParams={false}
+                fromParams={true}
                 handleByTextChange={function(val) {
                   return val;
                 }}

--- a/src/shacl/Shacl.js
+++ b/src/shacl/Shacl.js
@@ -98,6 +98,7 @@ export function mkShaclTabs(shacl, setShacl, name, subname) {
   return (
     <React.Fragment>
       <ShaclTabs
+        shacl={shacl}
         name={name}
         subname={subname}
         activeSource={shacl.activeSource}
@@ -115,6 +116,7 @@ export function mkShaclTabs(shacl, setShacl, name, subname) {
         resetFromParams={resetParams}
       />
       <SelectSHACLEngine
+        shacl={shacl}
         handleEngineChange={handleSHACLEngineChange}
         selectedEngine={shacl.engine}
         fromParams={shacl.fromParams}
@@ -122,6 +124,7 @@ export function mkShaclTabs(shacl, setShacl, name, subname) {
       />
 
       <SelectInferenceEngine
+        shacl={shacl}
         handleInferenceChange={handleInferenceChange}
         selectedInference={shacl.inference}
         fromParams={shacl.fromParams}

--- a/src/shacl/ShaclConvert.js
+++ b/src/shacl/ShaclConvert.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import qs from "query-string";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -12,6 +12,7 @@ import API from "../API";
 import PageHeader from "../components/PageHeader";
 import { SelectSHACLEngine } from "../components/SelectEngine";
 import SelectFormat from "../components/SelectFormat";
+import { ApplicationContext } from "../context/ApplicationContext";
 import { mkPermalinkLong, params2Form } from "../Permalink";
 import ResultSchemaConvert from "../results/ResultSchemaConvert";
 import { mkError } from "../utils/ResponseError";
@@ -46,6 +47,8 @@ function ShaclConvert(props) {
 
   const [disabledLinks, setDisabledLinks] = useState(false);
 
+  const { shaclSchema: ctxShacl } = useContext(ApplicationContext);
+
   const urlConvert = API.routes.server.schemaConvert;
 
   useEffect(() => {
@@ -66,17 +69,19 @@ function ShaclConvert(props) {
           targetSchemaEngine;
         setTargetSchemaEngine(finalTargetEngine);
 
-        const params = mkParams(
+        const newParams = mkParams(
           finalSchema,
           finalTargetFormat,
           finalTargetEngine
         );
 
-        setParams(params);
-        setLastParams(params);
+        setParams(newParams);
+        setLastParams(newParams);
       } else {
         setError(API.texts.errorParsingUrl);
       }
+    } else {
+      if (ctxShacl && typeof ctxShacl === "object") setShacl(ctxShacl);
     }
   }, [props.location?.search]);
 

--- a/src/shacl/ShaclConvert.js
+++ b/src/shacl/ShaclConvert.js
@@ -25,6 +25,10 @@ import {
 } from "./Shacl";
 
 function ShaclConvert(props) {
+  const { shaclSchema: ctxShacl } = useContext(ApplicationContext);
+
+  const [shacl, setShacl] = useState(ctxShacl || InitialShacl);
+
   const [targetSchemaFormat, setTargetSchemaFormat] = useState(
     API.formats.defaultShacl
   );
@@ -32,8 +36,6 @@ function ShaclConvert(props) {
   const [targetSchemaEngine, setTargetSchemaEngine] = useState(
     API.engines.shaclex
   );
-
-  const [shacl, setShacl] = useState(InitialShacl);
 
   const [result, setResult] = useState("");
 
@@ -46,8 +48,6 @@ function ShaclConvert(props) {
   const [progressPercent, setProgressPercent] = useState(0);
 
   const [disabledLinks, setDisabledLinks] = useState(false);
-
-  const { shaclSchema: ctxShacl } = useContext(ApplicationContext);
 
   const urlConvert = API.routes.server.schemaConvert;
 
@@ -80,8 +80,6 @@ function ShaclConvert(props) {
       } else {
         setError(API.texts.errorParsingUrl);
       }
-    } else {
-      if (ctxShacl && typeof ctxShacl === "object") setShacl(ctxShacl);
     }
   }, [props.location?.search]);
 

--- a/src/shacl/ShaclInfo.js
+++ b/src/shacl/ShaclInfo.js
@@ -23,7 +23,9 @@ import {
 } from "./Shacl";
 
 function ShaclInfo(props) {
-  const [shacl, setShacl] = useState(InitialShacl);
+  const { shaclSchema: ctxShacl } = useContext(ApplicationContext);
+
+  const [shacl, setShacl] = useState(ctxShacl || InitialShacl);
 
   const [result, setResult] = useState("");
 
@@ -36,8 +38,6 @@ function ShaclInfo(props) {
   const [progressPercent, setProgressPercent] = useState(0);
 
   const [disabledLinks, setDisabledLinks] = useState(false);
-
-  const { shaclSchema: ctxShacl } = useContext(ApplicationContext);
 
   const urlInfo = API.routes.server.schemaInfo;
   const urlVisual = API.routes.server.schemaConvert;
@@ -57,8 +57,6 @@ function ShaclInfo(props) {
       } else {
         setError(API.texts.errorParsingUrl);
       }
-    } else {
-      if (ctxShacl && typeof ctxShacl === "object") setShacl(ctxShacl);
     }
   }, [props.location?.search]);
 

--- a/src/shacl/ShaclInfo.js
+++ b/src/shacl/ShaclInfo.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import qs from "query-string";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -10,6 +10,7 @@ import ProgressBar from "react-bootstrap/ProgressBar";
 import Row from "react-bootstrap/Row";
 import API from "../API";
 import PageHeader from "../components/PageHeader";
+import { ApplicationContext } from "../context/ApplicationContext";
 import { mkPermalinkLong, params2Form } from "../Permalink";
 import ResultSchemaInfo from "../results/ResultSchemaInfo";
 import { mkError } from "../utils/ResponseError";
@@ -36,6 +37,8 @@ function ShaclInfo(props) {
 
   const [disabledLinks, setDisabledLinks] = useState(false);
 
+  const { shaclSchema: ctxShacl } = useContext(ApplicationContext);
+
   const urlInfo = API.routes.server.schemaInfo;
   const urlVisual = API.routes.server.schemaConvert;
 
@@ -47,13 +50,15 @@ function ShaclInfo(props) {
         const finalSchema = updateStateShacl(queryParams, shacl) || shacl;
         setShacl(finalSchema);
 
-        const params = mkParams(finalSchema);
+        const newParams = mkParams(finalSchema);
 
-        setParams(params);
-        setLastParams(params);
+        setParams(newParams);
+        setLastParams(newParams);
       } else {
         setError(API.texts.errorParsingUrl);
       }
+    } else {
+      if (ctxShacl && typeof ctxShacl === "object") setShacl(ctxShacl);
     }
   }, [props.location?.search]);
 

--- a/src/shacl/ShaclTabs.js
+++ b/src/shacl/ShaclTabs.js
@@ -1,29 +1,39 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useContext, useEffect } from "react";
 import API from "../API";
 import InputTabsWithFormat from "../components/InputTabsWithFormat";
+import { ApplicationContext } from "../context/ApplicationContext";
 
 function ShaclTabs(props) {
+  // Get schema and its setter from context
+  const { shaclSchema: ctxShacl, setShaclSchema: setCtxShacl } = useContext(
+    ApplicationContext
+  );
+
+  // Change context when the contained schema changes
+  useEffect(() => {
+    setCtxShacl(props.shacl);
+  }, [props.shacl]);
   return (
     <div>
       <InputTabsWithFormat
         nameInputTab={props.name}
-        activeSource={props.activeSource}
+        activeSource={props.activeSource || ctxShacl.activeSource}
         handleTabChange={props.handleTabChange}
         byTextName={props.subname}
-        textAreaValue={props.textAreaValue}
+        textAreaValue={props.textAreaValue || ctxShacl.textArea}
         byTextPlaceholder={API.texts.placeholders.shacl}
         handleByTextChange={props.handleByTextChange}
         handleUrlChange={props.handleDataUrlChange}
-        urlValue={props.urlValue}
+        urlValue={props.urlValue || ctxShacl.url}
         byURLPlaceholder={API.texts.placeholders.url}
         handleFileUpload={props.handleFileUpload}
-        selectedFormat={props.selectedFormat}
-        selectedEngine={props.selectedEngine}
+        selectedFormat={props.selectedFormat || ctxShacl.format}
+        selectedEngine={props.selectedEngine || ctxShacl.engine}
         handleFormatChange={props.handleDataFormatChange}
         urlFormats={API.routes.server.shaclFormats}
         setCodeMirror={props.setCodeMirror}
-        fromParams={props.fromParams}
+        fromParams={props.fromParams || ctxShacl.fromParams}
         resetFromParams={props.resetFromParams}
       />
     </div>
@@ -31,6 +41,7 @@ function ShaclTabs(props) {
 }
 
 ShaclTabs.propTypes = {
+  shacl: PropTypes.object.isRequired,
   activeSource: PropTypes.string,
   handleTabChange: PropTypes.func.isRequired,
   textAreaValue: PropTypes.string,
@@ -41,9 +52,6 @@ ShaclTabs.propTypes = {
 
   selectedFormat: PropTypes.string.isRequired,
   handleDataFormatChange: PropTypes.func.isRequired,
-
-  // handleInferenceChange: PropTypes.func.isRequired,
-  // selectedInference: PropTypes.string.isRequired,
 
   resetFromParams: PropTypes.func,
   fromParams: PropTypes.bool,

--- a/src/shacl/ShaclValidate.js
+++ b/src/shacl/ShaclValidate.js
@@ -12,9 +12,7 @@ import API from "../API";
 import PageHeader from "../components/PageHeader";
 import { ApplicationContext } from "../context/ApplicationContext";
 import {
-  getDataText,
-  InitialData,
-  mkDataTabs,
+  getDataText, mkDataTabs,
   paramsFromStateData,
   updateStateData
 } from "../data/Data";
@@ -31,11 +29,19 @@ import {
 } from "./Shacl";
 
 function ShaclValidate(props) {
-  const [shacl, setShacl] = useState(InitialShacl);
-  const [data, setData] = useState(InitialData);
+  // Get all required data from state: data, schema
+  const {
+    rdfData: [ctxData],
+    addRdfData,
+    shaclSchema: ctxShacl,
+    validationEndpoint: ctxValidationEndpoint,
+  } = useContext(ApplicationContext);
 
-  const [endpoint, setEndpoint] = useState("");
-  const [withEndpoint, setWithEndpoint] = useState(false);
+  const [data, setData] = useState(ctxData || addRdfData());
+  const [shacl, setShacl] = useState(ctxShacl || InitialShacl);
+
+  const [endpoint, setEndpoint] = useState(ctxValidationEndpoint || "");
+  const [withEndpoint, setWithEndpoint] = useState(!!ctxValidationEndpoint);
 
   const [result, setResult] = useState("");
 
@@ -48,13 +54,6 @@ function ShaclValidate(props) {
   const [progressPercent, setProgressPercent] = useState(0);
 
   const [disabledLinks, setDisabledLinks] = useState(false);
-
-  // Get all required data from state: data, schema, shapemap
-  const {
-    rdfData: [ctxData],
-    shaclSchema: ctxShacl,
-    validationEndpoint: ctxValidationEndpoint,
-  } = useContext(ApplicationContext);
 
   const url = API.routes.server.schemaValidate;
 
@@ -79,13 +78,6 @@ function ShaclValidate(props) {
       const newParams = mkParams(finalData, finalShacl, finalEndpoint);
       setParams(newParams);
       setLastParams(newParams);
-    } else {
-      if (ctxData && typeof ctxData === "object") setData(ctxData);
-      if (ctxShacl && typeof ctxShacl === "object") setShacl(ctxShacl);
-      if (ctxValidationEndpoint && typeof ctxValidationEndpoint === "string") {
-        setEndpoint(ctxValidationEndpoint);
-        setWithEndpoint(!!ctxValidationEndpoint);
-      }
     }
   }, [props.location?.search]);
 

--- a/src/shapeMap/ShapeMap.js
+++ b/src/shapeMap/ShapeMap.js
@@ -80,6 +80,7 @@ export function mkShapeMapTabs(shapeMap, setShapeMap, name, subname) {
 
   return (
     <ShapeMapTabs
+      shapeMap={shapeMap}
       name={name}
       subname={subname}
       activeSource={shapeMap.activeSource}

--- a/src/shapeMap/ShapeMapInfo.js
+++ b/src/shapeMap/ShapeMapInfo.js
@@ -22,19 +22,23 @@ import {
 } from "./ShapeMap";
 
 function ShapeMapInfo(props) {
-  const [shapemap, setShapemap] = useState(InitialShapeMap);
+  // Recover user shapeMap from context, if any
+  const { shapeMap: ctxShapeMap } = useContext(ApplicationContext);
+
+  const [shapemap, setShapemap] = useState(ctxShapeMap || InitialShapeMap);
+
   const [result, setResult] = useState(null);
+
   const [params, setParams] = useState(null);
   const [lastParams, setLastParams] = useState(null);
+
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
   const [permalink, setPermalink] = useState(null);
+
   const [progressPercent, setProgressPercent] = useState(0);
 
   const [disabledLinks, setDisabledLinks] = useState(false);
-
-  // Recover user shapeMap from context, if any
-  const { shapeMap: ctxShapeMap } = useContext(ApplicationContext);
 
   const url = API.routes.server.shapeMapInfo;
 
@@ -50,9 +54,6 @@ function ShapeMapInfo(props) {
         setParams(params);
         setLastParams(params);
       } else setError(API.texts.errorParsingUrl);
-    } else {
-      if (ctxShapeMap && typeof ctxShapeMap === "object")
-        setShapemap(ctxShapeMap);
     }
   }, [props.location?.search]);
 

--- a/src/shapeMap/ShapeMapInfo.js
+++ b/src/shapeMap/ShapeMapInfo.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import qs from "query-string";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -10,6 +10,7 @@ import ProgressBar from "react-bootstrap/ProgressBar";
 import Row from "react-bootstrap/Row";
 import API from "../API";
 import PageHeader from "../components/PageHeader";
+import { ApplicationContext } from "../context/ApplicationContext";
 import { mkPermalinkLong, params2Form } from "../Permalink";
 import ResultShapeMapInfo from "../results/ResultShapeMapInfo";
 import { mkError } from "../utils/ResponseError";
@@ -32,6 +33,9 @@ function ShapeMapInfo(props) {
 
   const [disabledLinks, setDisabledLinks] = useState(false);
 
+  // Recover user shapeMap from context, if any
+  const { shapeMap: ctxShapeMap } = useContext(ApplicationContext);
+
   const url = API.routes.server.shapeMapInfo;
 
   useEffect(() => {
@@ -46,6 +50,9 @@ function ShapeMapInfo(props) {
         setParams(params);
         setLastParams(params);
       } else setError(API.texts.errorParsingUrl);
+    } else {
+      if (ctxShapeMap && typeof ctxShapeMap === "object")
+        setShapemap(ctxShapeMap);
     }
   }, [props.location?.search]);
 

--- a/src/shapeMap/ShapeMapTabs.js
+++ b/src/shapeMap/ShapeMapTabs.js
@@ -1,28 +1,39 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useContext, useEffect } from "react";
 import API from "../API";
 import InputTabsWithFormat from "../components/InputTabsWithFormat";
+import { ApplicationContext } from "../context/ApplicationContext";
 
 function ShapeMapTabs(props) {
+  // Get shapeMap and its setter from context
+  const { shapeMap: ctxShapeMap, setShapeMap: setCtxShapeMap } = useContext(
+    ApplicationContext
+  );
+
+  // Change context when the contained shapeMap changes
+  useEffect(() => {
+    setCtxShapeMap(props.shapeMap);
+  }, [props.shapeMap]);
+
   return (
     <div>
       <InputTabsWithFormat
         defaultFormat={API.formats.defaultShapeMap}
         nameInputTab={props.name}
-        activeSource={props.activeSource}
+        activeSource={props.activeSource || ctxShapeMap.activeSource}
         handleTabChange={props.handleTabChange}
         byTextName={props.subname}
-        textAreaValue={props.textAreaValue}
+        textAreaValue={props.textAreaValue || ctxShapeMap.textArea}
         byTextPlaceholder={API.texts.placeholders.shapeMap}
         handleByTextChange={props.handleByTextChange}
         handleUrlChange={props.handleUrlChange}
-        urlValue={props.urlValue}
+        urlValue={props.urlValue || ctxShapeMap.url}
         byURLPlaceholder={API.texts.placeholders.url}
         handleFileUpload={props.handleFileUpload}
-        selectedFormat={props.selectedFormat}
+        selectedFormat={props.selectedFormat || ctxShapeMap.format}
         handleFormatChange={props.handleFormatChange}
         urlFormats={API.routes.server.shapeMapFormats}
-        fromParams={props.fromParams}
+        fromParams={props.fromParams || ctxShapeMap.fromParams}
         resetFromParams={props.resetFromParams}
         setCodeMirror={props.setCodeMirror}
       />
@@ -31,6 +42,9 @@ function ShapeMapTabs(props) {
 }
 
 ShapeMapTabs.propTypes = {
+  /** Application shapeMap data */
+  shapeMap: PropTypes.object.isRequired,
+
   /** Active source */
   activeSource: PropTypes.string,
 

--- a/src/shex/Shex.js
+++ b/src/shex/Shex.js
@@ -100,6 +100,7 @@ export function mkShexTabs(shex, setShex, name, subname) {
 
   return (
     <ShexTabs
+      shex={shex}
       name={name}
       subname={subname}
       activeSource={shex.activeSource}

--- a/src/shex/ShexConvert.js
+++ b/src/shex/ShexConvert.js
@@ -35,6 +35,10 @@ import {
 } from "./Shex";
 
 function ShexConvert(props) {
+  const { shexSchema: ctxShex } = useContext(ApplicationContext);
+
+  const [shex, setShex] = useState(ctxShex || InitialShex);
+
   const [targetSchemaFormat, setTargetSchemaFormat] = useState(
     API.formats.defaultShex
   );
@@ -42,7 +46,6 @@ function ShexConvert(props) {
   const [targetSchemaEngine, setTargetSchemaEngine] = useState(
     API.engines.shex
   );
-  const [shex, setShex] = useState(InitialShex);
 
   const [result, setResult] = useState("");
 
@@ -55,8 +58,6 @@ function ShexConvert(props) {
   const [progressPercent, setProgressPercent] = useState(0);
 
   const [disabledLinks, setDisabledLinks] = useState(false);
-
-  const { shexSchema: ctxShex } = useContext(ApplicationContext);
 
   const urlConvert = API.routes.server.schemaConvert;
 
@@ -112,8 +113,6 @@ function ShexConvert(props) {
       } else {
         setError(API.texts.errorParsingUrl);
       }
-    } else {
-      if (ctxShex && typeof ctxShex === "object") setShex(ctxShex);
     }
   }, [props.location?.search]);
 

--- a/src/shex/ShexConvert.js
+++ b/src/shex/ShexConvert.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import qs from "query-string";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -18,6 +18,7 @@ import {
   shaclEngines
 } from "../components/SelectEngine";
 import SelectFormat from "../components/SelectFormat";
+import { ApplicationContext } from "../context/ApplicationContext";
 import { mkPermalinkLong, params2Form } from "../Permalink";
 import ResultSchemaConvert from "../results/ResultSchemaConvert";
 import ResultShapeForm from "../results/ResultShapeForm";
@@ -54,6 +55,8 @@ function ShexConvert(props) {
   const [progressPercent, setProgressPercent] = useState(0);
 
   const [disabledLinks, setDisabledLinks] = useState(false);
+
+  const { shexSchema: ctxShex } = useContext(ApplicationContext);
 
   const urlConvert = API.routes.server.schemaConvert;
 
@@ -109,6 +112,8 @@ function ShexConvert(props) {
       } else {
         setError(API.texts.errorParsingUrl);
       }
+    } else {
+      if (ctxShex && typeof ctxShex === "object") setShex(ctxShex);
     }
   }, [props.location?.search]);
 

--- a/src/shex/ShexForm.js
+++ b/src/shex/ShexForm.js
@@ -22,9 +22,9 @@ function ShexForm(props) {
       const y = YASHE.fromTextArea(textAreaRef.current, options);
       if (props.setCodeMirror) props.setCodeMirror(y);
       y.on("change", (cm, change) => {
-        props.onChange && props.onChange(cm.getValue(), y);
+        props.onChange && props.onChange(cm.getValue(), cm, change);
       });
-      y.setValue(props.value);
+      props.value && y.setValue(props.value);
       y.refresh();
       setYashe(y);
     } else if (props.fromParams) {

--- a/src/shex/ShexInfo.js
+++ b/src/shex/ShexInfo.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import qs from "query-string";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -10,6 +10,7 @@ import ProgressBar from "react-bootstrap/ProgressBar";
 import Row from "react-bootstrap/Row";
 import API from "../API";
 import PageHeader from "../components/PageHeader";
+import { ApplicationContext } from "../context/ApplicationContext";
 import { mkPermalinkLong, params2Form } from "../Permalink";
 import ResultSchemaInfo from "../results/ResultSchemaInfo";
 import { mkError } from "../utils/ResponseError";
@@ -36,6 +37,8 @@ function ShexInfo(props) {
 
   const [disabledLinks, setDisabledLinks] = useState(false);
 
+  const { shexSchema: ctxShex } = useContext(ApplicationContext);
+
   const urlInfo = API.routes.server.schemaInfo;
   const urlVisual = API.routes.server.schemaConvert;
 
@@ -47,13 +50,15 @@ function ShexInfo(props) {
         const finalSchema = updateStateShex(queryParams, shex) || shex;
         setShEx(finalSchema);
 
-        const params = mkParams(finalSchema);
+        const newParams = mkParams(finalSchema);
 
-        setParams(params);
-        setLastParams(params);
+        setParams(newParams);
+        setLastParams(newParams);
       } else {
         setError(API.texts.errorParsingUrl);
       }
+    } else {
+      if (ctxShex && typeof ctxShex === "object") setShEx(ctxShex);
     }
   }, [props.location?.search]);
 

--- a/src/shex/ShexInfo.js
+++ b/src/shex/ShexInfo.js
@@ -23,7 +23,9 @@ import {
 } from "./Shex";
 
 function ShexInfo(props) {
-  const [shex, setShEx] = useState(InitialShex);
+  const { shexSchema: ctxShex } = useContext(ApplicationContext);
+
+  const [shex, setShEx] = useState(ctxShex || InitialShex);
 
   const [result, setResult] = useState("");
 
@@ -36,8 +38,6 @@ function ShexInfo(props) {
   const [progressPercent, setProgressPercent] = useState(0);
 
   const [disabledLinks, setDisabledLinks] = useState(false);
-
-  const { shexSchema: ctxShex } = useContext(ApplicationContext);
 
   const urlInfo = API.routes.server.schemaInfo;
   const urlVisual = API.routes.server.schemaConvert;
@@ -57,8 +57,6 @@ function ShexInfo(props) {
       } else {
         setError(API.texts.errorParsingUrl);
       }
-    } else {
-      if (ctxShex && typeof ctxShex === "object") setShEx(ctxShex);
     }
   }, [props.location?.search]);
 

--- a/src/shex/ShexTabs.js
+++ b/src/shex/ShexTabs.js
@@ -1,28 +1,39 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useContext, useEffect } from "react";
 import API from "../API";
 import InputTabsWithFormat from "../components/InputTabsWithFormat";
+import { ApplicationContext } from "../context/ApplicationContext";
 
 function ShexTabs(props) {
+  // Get schema and its setter from context
+  const { shexSchema: ctxShex, setShexSchema: setCtxShex } = useContext(
+    ApplicationContext
+  );
+
+  // Change context when the contained schema changes
+  useEffect(() => {
+    setCtxShex(props.shex);
+  }, [props.shex]);
+
   return (
     <div>
       <InputTabsWithFormat
         nameInputTab={props.name}
-        activeSource={props.activeSource}
+        activeSource={props.activeSource || ctxShex.activeSource}
         handleTabChange={props.handleTabChange}
         byTextName={props.subname}
-        textAreaValue={props.textAreaValue}
+        textAreaValue={props.textAreaValue || ctxShex.textArea}
         byTextPlaceholder={API.texts.placeholders.shex}
         handleByTextChange={props.handleByTextChange}
         setCodeMirror={props.setCodeMirror}
         handleUrlChange={props.handleShExUrlChange}
-        urlValue={props.urlValue}
+        urlValue={props.urlValue || ctxShex.url}
         byURLPlaceholder={API.texts.placeholders.url}
         handleFileUpload={props.handleFileUpload}
-        selectedFormat={props.selectedFormat}
+        selectedFormat={props.selectedFormat || ctxShex.format}
         handleFormatChange={props.handleShExFormatChange}
         urlFormats={API.routes.server.shExFormats}
-        fromParams={props.fromParams}
+        fromParams={props.fromParams || ctxShex.fromParams}
         resetFromParams={props.resetFromParams}
       />
     </div>
@@ -30,6 +41,7 @@ function ShexTabs(props) {
 }
 
 ShexTabs.propTypes = {
+  shex: PropTypes.object.isRequired,
   activeSource: PropTypes.string,
   handleTabChange: PropTypes.func.isRequired,
   textAreaValue: PropTypes.string,

--- a/src/shex/ShexValidate.js
+++ b/src/shex/ShexValidate.js
@@ -12,9 +12,7 @@ import API from "../API";
 import PageHeader from "../components/PageHeader";
 import { ApplicationContext } from "../context/ApplicationContext";
 import {
-  getDataText,
-  InitialData,
-  mkDataTabs,
+  getDataText, mkDataTabs,
   paramsFromStateData,
   updateStateData
 } from "../data/Data";
@@ -38,9 +36,17 @@ import {
 } from "./Shex";
 
 function ShexValidate(props) {
-  const [data, setData] = useState(InitialData);
-  const [shex, setShEx] = useState(InitialShex);
-  const [shapeMap, setShapeMap] = useState(InitialShapeMap);
+  // Get all required data from state: data, schema, shapemap
+  const {
+    rdfData: [ctxData],
+    shexSchema: ctxShex,
+    shapeMap: ctxShapeMap,
+    addRdfData,
+  } = useContext(ApplicationContext);
+
+  const [data, setData] = useState(ctxData || addRdfData());
+  const [shex, setShEx] = useState(ctxShex || InitialShex);
+  const [shapeMap, setShapeMap] = useState(ctxShapeMap || InitialShapeMap);
 
   const [endpoint, setEndpoint] = useState("");
   const [withEndpoint, setWithEndpoint] = useState(false); // UI reference
@@ -56,13 +62,6 @@ function ShexValidate(props) {
   const [progressPercent, setProgressPercent] = useState(0);
 
   const [disabledLinks, setDisabledLinks] = useState(false);
-
-  // Get all required data from state: data, schema, shapemap
-  const {
-    rdfData: [ctxData],
-    shexSchema: ctxShex,
-    shapeMap: ctxShapeMap,
-  } = useContext(ApplicationContext);
 
   const url = API.routes.server.schemaValidate;
 
@@ -101,11 +100,6 @@ function ShexValidate(props) {
 
       setParams(newParams);
       setLastParams(newParams);
-    } else {
-      if (ctxData && typeof ctxData === "object") setData(ctxData);
-      if (ctxShex && typeof ctxShex === "object") setShEx(ctxShex);
-      if (ctxShapeMap && typeof ctxShapeMap === "object")
-        setShapeMap(ctxShapeMap);
     }
   }, [props.location?.search]);
 

--- a/src/shex/ShexValidate.js
+++ b/src/shex/ShexValidate.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import qs from "query-string";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -10,6 +10,7 @@ import ProgressBar from "react-bootstrap/ProgressBar";
 import Row from "react-bootstrap/Row";
 import API from "../API";
 import PageHeader from "../components/PageHeader";
+import { ApplicationContext } from "../context/ApplicationContext";
 import {
   getDataText,
   InitialData,
@@ -56,17 +57,24 @@ function ShexValidate(props) {
 
   const [disabledLinks, setDisabledLinks] = useState(false);
 
+  // Get all required data from state: data, schema, shapemap
+  const {
+    rdfData: [ctxData],
+    shexSchema: ctxShex,
+    shapeMap: ctxShapeMap,
+  } = useContext(ApplicationContext);
+
   const url = API.routes.server.schemaValidate;
 
   useEffect(() => {
     if (props.location?.search) {
       const queryParams = qs.parse(props.location.search);
-      let paramsData,
-        paramsShex,
-        paramsShapeMap = {};
 
       // Data from URL or default
-      const finalData = updateStateData(queryParams, data) || data;
+      const finalData = {
+        index: 0,
+        ...(updateStateData(queryParams, data) || data),
+      };
       setData(finalData);
 
       // Shex
@@ -93,6 +101,11 @@ function ShexValidate(props) {
 
       setParams(newParams);
       setLastParams(newParams);
+    } else {
+      if (ctxData && typeof ctxData === "object") setData(ctxData);
+      if (ctxShex && typeof ctxShex === "object") setShEx(ctxShex);
+      if (ctxShapeMap && typeof ctxShapeMap === "object")
+        setShapeMap(ctxShapeMap);
     }
   }, [props.location?.search]);
 

--- a/src/shex/Xmi2Shex.js
+++ b/src/shex/Xmi2Shex.js
@@ -25,7 +25,10 @@ import { mkError } from "../utils/ResponseError";
 import { getConverterInput } from "../utils/xmiUtils/shumlexUtils";
 
 export default function Xmi2Shex(props) {
-  const [uml, setUml] = useState(InitialUML);
+  // Recover user input data from context, if any. Use first item of the data array
+  const { umlData: ctxUml } = useContext(ApplicationContext);
+
+  const [uml, setUml] = useState(ctxUml || InitialUML);
 
   const [result, setResult] = useState(null);
 
@@ -38,9 +41,6 @@ export default function Xmi2Shex(props) {
   const [progressPercent, setProgressPercent] = useState(0);
 
   const [disabledLinks, setDisabledLinks] = useState(false);
-
-  // Recover user input data from context, if any. Use first item of the data array
-  const { umlData: ctxUml } = useContext(ApplicationContext);
 
   useEffect(() => {
     if (props.location?.search) {
@@ -72,8 +72,6 @@ export default function Xmi2Shex(props) {
         setUpHistory();
         doRequest();
       }
-    } else {
-      if (ctxUml && typeof ctxUml === "object") setUml(ctxUml);
     }
   }, [params]);
 

--- a/src/shex/Xmi2Shex.js
+++ b/src/shex/Xmi2Shex.js
@@ -1,6 +1,6 @@
 //import SelectFormat from "../components/SelectFormat"
 import qs from "query-string";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -11,6 +11,7 @@ import Row from "react-bootstrap/Row";
 import shumlex from "shumlex";
 import API from "../API";
 import PageHeader from "../components/PageHeader";
+import { ApplicationContext } from "../context/ApplicationContext";
 import { mkPermalinkLong } from "../Permalink";
 import ResultXmi2Shex from "../results/ResultXmi2Shex";
 import {
@@ -37,6 +38,9 @@ export default function Xmi2Shex(props) {
   const [progressPercent, setProgressPercent] = useState(0);
 
   const [disabledLinks, setDisabledLinks] = useState(false);
+
+  // Recover user input data from context, if any. Use first item of the data array
+  const { umlData: ctxUml } = useContext(ApplicationContext);
 
   useEffect(() => {
     if (props.location?.search) {
@@ -68,6 +72,8 @@ export default function Xmi2Shex(props) {
         setUpHistory();
         doRequest();
       }
+    } else {
+      if (ctxUml && typeof ctxUml === "object") setUml(ctxUml);
     }
   }, [params]);
 

--- a/src/uml/UML.js
+++ b/src/uml/UML.js
@@ -79,6 +79,7 @@ export function mkUMLTabs(uml, setUml, name, subname) {
 
   return (
     <UMLTabs
+      uml={uml}
       name={name}
       subname={subname}
       activeSource={uml.activeSource}

--- a/src/uml/UMLTabs.js
+++ b/src/uml/UMLTabs.js
@@ -1,9 +1,20 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useContext, useEffect } from "react";
 import API from "../API";
 import InputTabs from "../components/InputTabs";
+import { ApplicationContext } from "../context/ApplicationContext";
 
 function UMLTabs(props) {
+  // Get UML and its setter from context
+  const { umlData: ctxUml, setUmlData: setCtxUml } = useContext(
+    ApplicationContext
+  );
+
+  // Change context when the contained UML changes
+  useEffect(() => {
+    setCtxUml(props.uml);
+  }, [props.uml]);
+
   const umlForm = null;
   return (
     <div>
@@ -32,6 +43,7 @@ function UMLTabs(props) {
 }
 
 UMLTabs.propTypes = {
+  uml: PropTypes.object.isRequired,
   activeSource: PropTypes.string,
   handleTabChange: PropTypes.func.isRequired,
   textAreaValue: PropTypes.string,
@@ -43,7 +55,6 @@ UMLTabs.propTypes = {
 
   handleFileUpload: PropTypes.func.isRequired,
   selectedFormat: PropTypes.string.isRequired,
-  //   handleShExFormatChange: PropTypes.func.isRequired,
 
   /** Flag to signal if values come from Params */
   fromParams: PropTypes.bool.isRequired,

--- a/src/uml/UMLTabs.js
+++ b/src/uml/UMLTabs.js
@@ -20,22 +20,22 @@ function UMLTabs(props) {
     <div>
       <InputTabs
         name={props.name}
-        activeSource={props.activeSource}
+        activeSource={props.activeSource || ctxUml.activeSource}
         handleTabChange={props.handleTabChange}
         byTextName={props.subname}
-        textAreaValue={props.textAreaValue}
+        textAreaValue={props.textAreaValue || ctxUml.textArea}
         byTextPlaceholder={API.texts.placeholders.xmi}
         handleByTextChange={props.handleByTextChange}
         setCodeMirror={props.setCodeMirror}
         inputForm={umlForm}
         handleUrlChange={props.handleXmiUrlChange}
-        urlValue={props.urlValue}
+        urlValue={props.urlValue || ctxUml.url}
         byURLPlaceholder={API.texts.placeholders.url}
         handleFileUpload={props.handleFileUpload}
-        mode={props.selectedFormat}
+        mode={props.selectedFormat || ctxUml.format}
         handleFormatChange={props.handleFormatChange}
         urlFormats={API.routes.server.shExFormats}
-        fromParams={props.fromParams}
+        fromParams={props.fromParams || ctxUml.fromParams}
         resetFromParams={props.resetFromParams}
       />
     </div>


### PR DESCRIPTION
A mechanism for data persistence between the client pages and tools has been setup using [React's Context API](https://reactjs.org/docs/context.html) and [Session Storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage).

Currently, the following user data is not lost between pages:
- RdfData (more than a single data instance can be stores, i.e.: for data merges)
- Validation schema
- ShapeMap
- SPARQL Query (+ query target/endpoint)
- XMI (UML) data