### PR TITLE
Fixed XML parser failures on some HTML outputs of ShapeForms

### DIFF
--- a/src/results/ResultShapeForm.js
+++ b/src/results/ResultShapeForm.js
@@ -66,10 +66,15 @@ function ResultShapeForm({ result: shapeFormResult, permalink, disabled }) {
         <Tabs activeKey={resultTab} onSelect={setResultTab} id="resultTabs">
           {/* HTML code for the generated form */}
           <Tab eventKey={API.tabs.html} title={API.texts.resultTabs.result}>
+            {console.info(form)}
             <ByText
-              textAreaValue={format(form, {
+              // Wrap generated form in SPAN to have a unique root node for XML parser
+              textAreaValue={format(`<span>${form}</span>`, {
                 indentation: "  ",
-              })} // Pretty print generated HTML
+              })
+                // Remove the spans placed for XML parsing
+                .replace(/^<span>/, "")
+                .replace(/<\/span>$/, "")} // Pretty print generated HTML
               textFormat={API.formats.xml}
               fromParams={true}
               readonly={true}


### PR DESCRIPTION
On some inputs, ShapeForms returns HTML with several root-level elements. For instance:
```
<form>
  ...form HTML
</form>
<span>...</span>
```

Our client-side XML formatter expected a single root element and crashed in these cases. This is temporarily fixed by wrapping the whole output of ShapeForms in `<span>`, `</span>` and removing those after the formatting.